### PR TITLE
CU-25131v Add Personal Info tests with Page Object structure

### DIFF
--- a/commands/clearValue2.js
+++ b/commands/clearValue2.js
@@ -1,0 +1,10 @@
+exports.command = function clearValue2(selector) {
+  const { RIGHT_ARROW, BACK_SPACE } = this.Keys
+  return this.getAttribute(selector, 'value', (result) => {
+    const chars = result.value.split('')
+    // Make sure we are at the end of the input
+    chars.forEach(() => this.setValue(selector, RIGHT_ARROW))
+    // Delete all the existing characters
+    chars.forEach(() => this.setValue(selector, BACK_SPACE))
+  })
+}

--- a/conf/personal_info.conf.js
+++ b/conf/personal_info.conf.js
@@ -1,0 +1,53 @@
+nightwatch_config = {
+    src_folders : [ "tests" ],
+  
+    selenium : {
+      "start_process" : false,
+      "host" : "hub-cloud.browserstack.com",
+      "port" : 443 //SSL
+    },
+  
+    test_settings: {
+      default: {
+        desiredCapabilities: {
+          'browserstack.user': 'nick34',
+          'browserstack.key': 'SBukT13jtljJiBWoBpHw',
+          'browserstack.debug': true,
+          'browserstack.networkLogs': true,
+          'os': 'OS X',
+          'os_version': 'Mojave',
+          'build' : 'Personal Info',
+          'project' : 'eVisit Nightwatch Core Regression',
+          'browser': 'Chrome',
+          'browser_version': '85.0.4183.102',
+          'resolution': '1920x1080',
+          // disable geolocation  - only required for browserstack
+          "chromeOptions" : {
+            prefs: {
+                // 0 - Default, 1 - Allow, 2 - Block
+                'profile.managed_default_content_settings.geolocation' : 1
+              }
+          }
+        },
+        globals: {
+            env: "staging",
+            handle: "omega",
+            email:"taylor+o14@evisit.com",
+            password:"patient123"
+          },
+      }
+    },
+    custom_commands_path: ["./commands"],
+    page_objects_path: ["pages"]
+  };
+
+  
+  // Code to copy seleniumhost/port into test settings
+  for(var i in nightwatch_config.test_settings){
+    var config = nightwatch_config.test_settings[i];
+    config['selenium_host'] = nightwatch_config.selenium.host;
+    config['selenium_port'] = nightwatch_config.selenium.port;
+  }
+  
+  module.exports = nightwatch_config;
+  

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "chromedriver": "^79.0.3",
+    "chromedriver": "^85.0.0",
     "geckodriver": "^1.19.1",
-    "nightwatch": "^1.3.6"
+    "nightwatch": "^1.4.2"
   }
 }

--- a/pages/geolocationPage.js
+++ b/pages/geolocationPage.js
@@ -1,0 +1,37 @@
+const elements = {
+    confirmCheckBox: `[data-test-id='confirmCheckBox']`,
+    btnContinue: `[data-test-id='continue']`
+};
+
+const commands = [{
+
+    confirmGeolocation() {
+        let self = this;
+        this
+            .api.element('@confirmCheckBox', function (result) {
+                //check if geolocation is requested
+                if (result.status != -1) {
+                    console.log("Starting Geolocation Page")
+                    //check and click confirm checkbox
+                    self
+                        .verify.elementPresent('@confirmCheckBox')
+                        .click('@confirmCheckBox')
+                        //check and click continue button
+                        .verify.elementPresent('@btnContinue')
+                        .click('@btnContinue')
+                        //pause
+                        .pause(6000)
+                } else {
+                    console.log("Skipping Geolocation Page")
+                    self.pause(6000)
+                }
+            })
+        return this
+    }
+
+}];
+
+module.exports = {
+    elements: elements,
+    commands: commands
+}

--- a/pages/landingPage.js
+++ b/pages/landingPage.js
@@ -1,0 +1,27 @@
+const elements = {
+    btnUserProfile: `[data-test-id='userProfileButton']`,
+    myAccountMenuItem: `[data-test-id='myAccountMenuItem']`
+};
+
+const commands = [{
+
+    selectMyAccount() {
+        console.log("Accessing My Account")
+        this
+            //verify and click user profile button
+            .waitForElementVisible('@btnUserProfile')
+            .verify.elementPresent('@btnUserProfile')
+            .click('@btnUserProfile')
+            //expect and click my account menu item
+            .verify.elementPresent('@myAccountMenuItem')
+            .click('@myAccountMenuItem')
+            .pause(3000)
+        return this
+    }
+
+}];
+
+module.exports = {
+    elements: elements,
+    commands: commands
+}

--- a/pages/loginPage.js
+++ b/pages/loginPage.js
@@ -1,0 +1,39 @@
+const elements = {
+    email: `[data-test-id='email']`,
+    password: `[data-test-id='password']`,
+    btnLogin: `[data-test-id='loginButton']`
+};
+
+const commands = [{
+
+    goToPracticeLoginPage() {
+        this.api.url(`https://${this.api.globals.env}.evisit.com/r/${this.api.globals.handle}/auth/LoginPage`)
+            .pause(3000)
+        return this
+    },
+
+    patientLogin() {
+        console.log("Starting Patient Login")
+        this
+            //check and set email
+            .waitForElementVisible('@email')
+            .verify.elementPresent('@email')
+            .setValue('@email', this.api.globals.email)
+            //check and set password
+            .waitForElementVisible('@password')
+            .setValue('@password', this.api.globals.password)
+            //expect and click login button
+            .waitForElementVisible('@password')
+            .click('@btnLogin')
+            // //wait for page to load
+            .pause(7000)
+
+        return this
+    }
+
+}];
+
+module.exports = {
+    elements: elements,
+    commands: commands
+}

--- a/pages/personalInfoPage.js
+++ b/pages/personalInfoPage.js
@@ -1,0 +1,88 @@
+const elements = {
+    personalInfoSection: `[data-test-id='personalInfoSection']`,
+
+    firstName: `[data-test-id='firstName']`,
+    middleName: `[data-test-id='middleName']`,
+    lastName: `[data-test-id='lastName']`,
+    addressLine1: `[data-test-id='addressLine1']`,
+    addressLine2: `[data-test-id='addressLine2']`,
+    city: `[data-test-id='city']`,
+    state: `[data-test-id="state"]`,
+    zipCode: `[data-test-id="zipCode"]`,
+    phoneCell: `[data-test-id="phoneCell"]`,
+    state: `input[data-test-id="state"]`,
+    dateOfBirth: `[data-test-id="dob"]`,
+    gender: `[data-test-id="gender"][name="sex"]`,
+    timeZone: `[data-test-id="timeZoneSelect"][name="timezone"]`,
+    
+    btnUpdate: `div.eVisitAppNavigationButtons:nth-child(3) > div:nth-child(1) > div:nth-child(1)`,
+    
+    toast: `[data-test-id='toast']`
+};
+
+const commands = [{
+    editPersonalInfo(firstNameValue, middleNameValue, lastNameValue, addressLine1Value, addressLine2Value, cityValue, stateValue,
+                        zipCodeValue, phoneCellValue, dateOfBirthValue, genderValue, timeZoneValue) {
+        this
+            .editTextField('@firstName', firstNameValue)
+            .editTextField('@middleName', middleNameValue)
+            .editTextField('@lastName', lastNameValue)
+            .editTextField('@addressLine1', addressLine1Value)
+            .editTextField('@addressLine2', addressLine2Value)
+            .editTextField('@city', cityValue)
+            .editComboboxField('@state', stateValue)
+            .editTextField('@zipCode', zipCodeValue)
+            .editTextField('@phoneCell', phoneCellValue)
+            .editTextField('@dateOfBirth', dateOfBirthValue)
+            .editComboboxField('@gender', genderValue)
+            .editComboboxField('@timeZone', timeZoneValue)
+            .clickUpdateButton()
+        return this
+    },
+    editTextField(locator, value) {
+        return this
+            .waitForElementVisible(locator)
+            //.click(locator)
+            .clearValue2(locator)
+            .setValue(locator, value)
+    },
+    editComboboxField(locator, value) {
+        return this
+            .click(locator)
+            .waitForElementVisible(locator)
+            .click(`[data-test-id=${value}]`)
+    },
+    clickUpdateButton() {
+        return this
+            .pause(2000)
+            .click('@btnUpdate')
+            .pause(2000)
+    },
+    checkToastMessage(message) {
+        return this
+            //.pause(3000)
+            .waitForElementVisible('@toast')
+            .verify.containsText('@toast', message)
+    },
+    checkPersistence(firstNameValue, middleNameValue, lastNameValue, addressLine1Value, addressLine2Value, cityValue, stateValue,
+        zipCodeValue, phoneCellValue, dateOfBirthValue, genderValue, timeZoneValue){
+            this.verify.attributeEquals('@firstName', 'value', firstNameValue);
+            this.verify.attributeEquals('@middleName','value', middleNameValue);
+            this.verify.attributeEquals('@lastName','value', lastNameValue);
+            this.verify.attributeEquals('@addressLine1','value', addressLine1Value);
+            this.verify.attributeEquals('@addressLine2','value', addressLine2Value);
+            this.verify.attributeEquals('@city','value', cityValue);
+            this.verify.attributeEquals('@state','value', stateValue);
+            this.verify.attributeEquals('@zipCode','value', zipCodeValue);
+            this.verify.attributeEquals('@phoneCell','value', phoneCellValue);
+            this.verify.attributeEquals('@dateOfBirth','value', dateOfBirthValue);
+            this.verify.attributeEquals('@gender','value', genderValue);
+            this.verify.attributeEquals('@timeZone','value', timeZoneValue)
+            return this
+        }
+}];
+
+module.exports = {
+    elements: elements,
+    commands: commands
+}

--- a/tests/my_account/personal_info.js
+++ b/tests/my_account/personal_info.js
@@ -1,0 +1,32 @@
+module.exports = {
+    before: function (browser) {
+        browser.resizeWindow(1920, 1080);
+        '@tags:'['test']
+    },
+    //This test edit all fiedls of Personal Info considering the happy path
+    "Edit Personal Info Successfully": function (browser) {
+        const loginPage = browser.page.loginPage()
+        const geolocationPage = browser.page.geolocationPage()
+        const landingPage = browser.page.landingPage()
+        const personalInfoPage = browser.page.personalInfoPage()
+
+        loginPage
+            .goToPracticeLoginPage()
+            .patientLogin()
+        geolocationPage.confirmGeolocation()
+        landingPage.selectMyAccount()
+        personalInfoPage.verify.elementPresent('@personalInfoSection')
+        //edit fields in Personal Info form according to parameters values
+        personalInfoPage.editPersonalInfo("First Name Edited", "Middle Name Edited","Last Name Edited", "Address 1 Edited",
+        "Address 2 Edited", "City Edited", "WyomingOption", "12345", "123-456-7891", "09/06/1990", "femaleOption", "AmericaNoronha020200Option")
+        //check Success toast
+        personalInfoPage.checkToastMessage("Personal Info updated.")
+        //check if all fields were saved as informed previously
+        personalInfoPage.checkPersistence("First Name Edited", "Middle Name Edited","Last Name Edited", "Address 1 Edited",
+        "Address 2 Edited", "City Edited", "Wyoming", "12345", "123-456-7891", "09/06/1990", "Female", "America/Noronha (-02 -0200)")
+    },
+
+    after: function (browser) {
+        browser.end();
+    }
+};


### PR DESCRIPTION
Sorry for the number of files!
These changes do not interfere in the execution of the existing tests but it proposes a structure that allows the reuse of common steps.

Note: clearValue2.js is a custom command I had to include since .clearValue() is not working.

To run the test I used the following command:
`./node_modules/.bin/nightwatch -c conf/personal_info.conf.js -t ./tests/my_account/personal_info.js`