### PR TITLE
fix for Toggle Notification Tests on Provider and Patient

### DIFF
--- a/pages/patient/my_account/settingsPage.js
+++ b/pages/patient/my_account/settingsPage.js
@@ -12,11 +12,11 @@ const elements = {
 
     emailNotifField: `[name*="default.email"]`,
     phoneNotifField: `[name*="default.voice"]`,
-    textNotifField: `[name*="default.sms"]`,
+    smsNotifField: `[name*="default.sms"]`,
 
     emailNotifToggle: `[data-test-id="emailToggle"] [class="RAView eVisitAppSwitchFieldKnob"]`,
     phoneNotifToggle: `[data-test-id="voiceToggle"] [class="RAView eVisitAppSwitchFieldKnob"]`,
-    textNotifToggle: `[data-test-id="smsToggle"] [class="RAView eVisitAppSwitchFieldKnob"]`,
+    smsNotifToggle: `[data-test-id="smsToggle"] [class="RAView eVisitAppSwitchFieldKnob"]`,
 
     saveChangesButton: `[data-test-id="saveNotificationChanges"]`,
     saveChangesSpinner: `[class="applicationActivityIndicator"]`
@@ -82,7 +82,7 @@ const commands = [{
         return this
             .verify.attributeEquals('@emailNotifField', 'value', emailNotifValue)
             .verify.attributeEquals('@phoneNotifField', 'value', phoneNotifValue)
-            .verify.attributeEquals('@textNotifField', 'value', textNotifValue)
+            .verify.attributeEquals('@smsNotifField', 'value', textNotifValue)
     },
 
     /* Check status of toggle
@@ -91,22 +91,40 @@ const commands = [{
         return this.verify.attributeContains(toggleLocator, 'style', value)
     },
 
-    //Toggle channel and verify if the toggle has the new status after saving
-    toggleNotifChannelandCheck(toggleLocator){
-        return this.getAttribute(toggleLocator, 'style', (result) => {
-            if(result.value.includes('right')){ //it means channel is enabled
-                this.click(toggleLocator) //toggle channel OFF
-                    .click('@saveChangesButton')
-                    .waitForElementNotVisible('@saveChangesSpinner')
-                    .checkToggleStatus(toggleLocator, 'left') //check if channel is disabled
+    /* Toggle all default channels and verify if their toggles changed the status after saving
+    It requires that at least one toggle be enabled otherwise it will not be saved and it will fail */
+    toggleNotifChannelsAndCheck() {
+        var toggles = ['@smsNotifToggle', '@phoneNotifToggle', '@emailNotifToggle'];
+        var togglesStatus = [];
+        this.waitForElementVisible(toggles[0]);
+        for ( i = 0; i < toggles.length ; i++) {
+            var element = toggles[i];
+            ( (elementVar) => { //start wrapper code (anonymous function)
+            this.getAttribute(elementVar, 'style', (result) => {
+                if (result.value.includes('right')) { //it means channel is enabled
+                    togglesStatus.push('left');
+                    this.click(elementVar) //toggle channel OFF
+                }
+                else if (result.value.includes('left')) { //it means channel is disabled
+                    togglesStatus.push('right')
+                    this.click(elementVar) //toggle channel ON
+                }
+            });
+            })(element);//calling anonymous function passing the toggle element as variable
+        }
+        
+        this.perform(() => {
+            //Save changes
+            this
+            .click('@saveChangesButton')
+            .waitForElementNotVisible('@saveChangesSpinner')
+
+            //Check each toggle status after saving
+            for (i = 0; i < toggles.length; i++) {
+                this.checkToggleStatus(toggles[i], togglesStatus[i])
             }
-            else if(result.value.includes('left')){ //it means channel is disabled
-                this.click(toggleLocator) //toggle channel ON
-                    .click('@saveChangesButton')
-                    .waitForElementNotVisible('@saveChangesSpinner')
-                    .checkToggleStatus(toggleLocator, 'right') //check if channel is enabled
-           }
         })
+        return this
     }
 }];
 

--- a/tests/patient/my_account/settings_notifications_test.js
+++ b/tests/patient/my_account/settings_notifications_test.js
@@ -1,4 +1,9 @@
-let settingsPage;
+/*
+*   REQUIREMENTS TO RUN:
+*
+* - At least one notification toggle must be enabled and at least one must be disabled (otherwise the test will fail
+* if try to save changes when none of them be enabled after toggle changes).
+*/
 
 module.exports = {
     
@@ -14,7 +19,7 @@ module.exports = {
             //edit notification fields
             .editTextField('@emailNotifField', "test@evisit.com")
             .editTextField('@phoneNotifField', "555-555-5555")
-            .editTextField('@textNotifField', "555-555-5555")
+            .editTextField('@smsNotifField', "555-555-5555")
             .click('@saveChangesButton')
         
         //TODO: check confirmation toast when it exists - Bug #8aka6k
@@ -26,9 +31,7 @@ module.exports = {
     //TODO: Add new notification channel
 
     "Toogle Notification Channels": function (browser) {
-        settingsPage.toggleNotifChannelandCheck('@textNotifToggle')
-        settingsPage.toggleNotifChannelandCheck('@phoneNotifToggle')
-        settingsPage.toggleNotifChannelandCheck('@emailNotifToggle')
+        settingsPage.toggleNotifChannelsAndCheck()
 
         //TODO: check confirmation toast when it exists - Bug #8aka6k
         //TODO: check persistence - Depends on #275v9m - Verified with CSS workaround

--- a/tests/provider/my_account/notifications_test.js
+++ b/tests/provider/my_account/notifications_test.js
@@ -1,5 +1,14 @@
+/*
+*   REQUIREMENTS TO RUN:
+*
+* - At least one notification toggle must be enabled and at least one must be disabled (otherwise the test will fail
+* if try to save changes when none of them be enabled after toggle changes).
+* - It shouldn't have any custom notification previously added
+*/
+
 module.exports = {
     
+    //To run only one test, change this before function to 'beforeEach'
     before: function (browser) {
         browser.resizeWindow(1920, 1300);
         '@tags:'['test']
@@ -20,9 +29,8 @@ module.exports = {
     },
 
     "Toogle Notification Channels": function (browser) {
-        notificationsPage.toggleNotifChannelandCheck('@smsNotifToggle')
-        notificationsPage.toggleNotifChannelandCheck('@phoneNotifToggle')
-        notificationsPage.toggleNotifChannelandCheck('@emailNotifToggle')
+        notificationsPage.toggleNotifChannelsAndCheck()
+        
         //TODO: check confirmation toast when it exists - Bug #8aka6k
         //TODO: check persistence - Depends on #275v9m - Verified with CSS workaround
     },
@@ -39,7 +47,8 @@ module.exports = {
         //TODO: check confirmation toast when it exists - Bug #8aka6k
     },
 
-    "Test Select All Notify Me When Checkboxes": function (browser) {
+    "Select All Notify Me When Checkboxes": function (browser) {
+        //Check the changed status of "Select All" according to the previous status
         notificationsPage.selectAll('@selectAllNotifyMe',  isSelected => {
             //Logout, login and access Notifications Page again to check persistence
             notificationsPage.accessNotificationsSectionAfterLogout(browser.globals.providerEmail, browser.globals.providerPassword)
@@ -48,7 +57,8 @@ module.exports = {
         })
     },
 
-    "Test Select All Notify My Patients Checkboxes": function (browser) {
+    "Select All Notify My Patients Checkboxes": function (browser) {
+        //Check the changed status of "Select All" according to the previous status
         notificationsPage.selectAll('@selectAllNotifyMyPatients',  isSelected => {
             //Logout, login and access Notifications Page again to check persistence
             notificationsPage.accessNotificationsSectionAfterLogout(browser.globals.providerEmail, browser.globals.providerPassword)
@@ -57,7 +67,7 @@ module.exports = {
         })
     },
 
-    "Test Select Only One of Notify Me When Checkboxes": function (browser) {
+    "Select Only One of Notify Me When Checkboxes": function (browser) {
         notificationsPage.selectOnlyOne('@leftCheckbox1', '@selectAllNotifyMe')
         //Logout, login and access Notifications Page again to check persistence
         notificationsPage.accessNotificationsSectionAfterLogout(browser.globals.providerEmail, browser.globals.providerPassword)
@@ -65,7 +75,7 @@ module.exports = {
         notificationsPage.checkPersistenceOfSelectOnlyOneNotifyMe()
     },
 
-    "Test Select Only One of Notify My Patients Checkboxes": function (browser) {
+    "Select Only One of Notify My Patients Checkboxes": function (browser) {
         notificationsPage.selectOnlyOne('@rightCheckbox1', '@selectAllNotifyMyPatients')
         //Logout, login and access Notifications Page again to check persistence
         notificationsPage.accessNotificationsSectionAfterLogout(browser.globals.providerEmail, browser.globals.providerPassword)


### PR DESCRIPTION
Changed the methods of toggle notification channels because the previous one changed one toggle at a time and tried to save (which sometimes ended up trying to save with no toggle enabled and this is not allowed by the feature).
Now, it changes all toggles at once before saving and checks the changes after.