### PR TITLE
Fix for Pharmacy and Toggle Notifications tests

### DIFF
--- a/commands/editTextField.js
+++ b/commands/editTextField.js
@@ -2,5 +2,6 @@ exports.command = function editTextField(locator, value) {
     return this
         //Removing this wait since another one will happen inside clearValue2 (20th october) - .waitForElementVisible(locator)
         .clearValue2(locator)
+        //.pause(1000) //It might be necessary to run locally to make sure the setvalue waits the cleaning
         .setValue(locator, value)
   }

--- a/pages/patient/my_account/pharmacyPage.js
+++ b/pages/patient/my_account/pharmacyPage.js
@@ -14,16 +14,17 @@ const elements = {
         index: 0
     },
 
-    // Second option of pharmacy returned by the list (to check the action of selecting a new one)
-    secondPharmacyOption: `[data-test-id="pharmacyRow1"]`,
-    secondPharmacyOptionName: `[data-test-id="pharmacyRow1"] [class="RAText"]:nth-child(1)`,
-    // First pharmacy of list
+    // First option of pharmacy returned by the list   
+    firstPharmacyOption: `[data-test-id="pharmacyRow0"]`,
+    // Icon of pharmacy to check if it is selected
     firstPharmacyOptionIcon: `[data-test-id="pharmacyRow0"] div[class*="RAView eVisitAppIcon eVisitAppIconContainer"]`,
+    // Name of the pharmacy (excluding the address)
     firstPharmacyOptionName: `[data-test-id="pharmacyRow0"] [class="RAText"]:nth-child(1)`,
 
     updateButton: `[data-test-id="updateEditPharmacy"]`,
 
-    newPhamacyOfMap: `[title="PHILLIPS DRUGS WEST"]`
+    //New pharmacy selected on the Map
+    newPhamacyOfMap: `[title="Phillips Drugs East"]`
 
 };
 
@@ -48,23 +49,25 @@ const commands = [{
     },
     searchBy(value) {
         this
+            .pause(1000)
             .editTextField('@searchField', value)
             //wait for popup with address options appears
-            .waitForElementVisible('@addressOption', 10000)
+            .waitForElementVisible(`[data-test-id="ZIPCODE` + value + `Option"]`,50000)
             //select the first address option
             .click('@addressOption')
+            .pause(2000) //necessary to wait the list of pharmacies update
         return this
     },
     selectByList() {
         this
-            .waitForElementVisible('@secondPharmacyOption')
+            .waitForElementVisible('@firstPharmacyOption')
             //get new pharmacy name to compare after
-            .getText('@secondPharmacyOptionName', (result) => {
+            .getText('@firstPharmacyOptionName', (result) => {
                 //new pharmacy name
                 const selectedPharmacy = result.value;
                 const settingsPage = this.api.page.patient.my_account.settingsPage();
                 //select new pharmacy on the list
-                this.click('@secondPharmacyOption')
+                this.click('@firstPharmacyOption')
                     //update pharmacy
                     .click('@updateButton')
                 //switch section in order to check the change to new pharmacy
@@ -93,14 +96,12 @@ const commands = [{
                 settingsPage.accessSettingsSection()
                 this.accessPharmacySection()
                     //check if selected pharmacy is centralized on Map
-                    .verify.cssProperty('@newPhamacyOfMap', 'left', '-10px')
-                    .verify.cssProperty('@newPhamacyOfMap', 'top', '-8px')
+                    .verify.cssProperty('@newPhamacyOfMap', 'left', '-16px') //previously -10
+                    .verify.cssProperty('@newPhamacyOfMap', 'top', '-14px') //previously -8
                     //check if selected pharmacy changed the icon color to 'selected' color
                     .verify.cssProperty('@firstPharmacyOptionIcon', 'background-color', 'rgba(42, 178, 188, 1)')
                     //check if the first position matches the selected pharmacy name
-                    .getText('@firstPharmacyOptionName', (firstPharmacyOptionNameText) =>{
-                        this.verify.equal((firstPharmacyOptionNameText.value).toUpperCase(), selectedPharmacy.toUpperCase() )
-                    })
+                    .expect.element('@firstPharmacyOptionName').text.to.equal(selectedPharmacy)
             })
         return this
 

--- a/pages/patient/my_account/settingsPage.js
+++ b/pages/patient/my_account/settingsPage.js
@@ -140,6 +140,7 @@ const commands = [{
             var element = toggles[i];
             ( (elementVar) => { //start wrapper code (anonymous function)
             this.getAttribute(elementVar, 'style', (result) => {
+                this.pause(1000)
                 if (result.value.includes('right')) { //it means channel is enabled
                     togglesStatus.push('left');
                     this.click(elementVar) //toggle channel OFF

--- a/pages/provider/my_account/notificationsPage.js
+++ b/pages/provider/my_account/notificationsPage.js
@@ -124,6 +124,7 @@ const commands = [{
             var element = toggles[i];
             ( (elementVar) => { //start wrapper code (anonymous function)
             this.getAttribute(elementVar, 'style', (result) => {
+                this.pause(1000)
                 if (result.value.includes('right')) { //it means channel is enabled
                     togglesStatus.push('left');
                     this.click(elementVar) //toggle channel OFF

--- a/tests/patient/my_account/pharmacy.js
+++ b/tests/patient/my_account/pharmacy.js
@@ -18,12 +18,12 @@ module.exports = {
             pharmacyPage.checkAddressInputByPatient(address.value)
         })
         pharmacyPage
-            //search by new address
-            .searchBy("Test")
+            //search by new address (by zipcode)
+            .searchBy("47374")
             //select new pharmacy by List
             .selectByList()
-            //search by new address
-            .searchBy("Test Road")
+            //search by new address (by zipcode)
+            .searchBy("47374")
             //select new pharmacy by Map
             .selectByMap()
     },


### PR DESCRIPTION
This PR has fixes for:
- Toggle notifications test for both patient and provider users. It was necessary to add a little more time (1s) while the toggle actions are performing to make sure they will have time to be executed and be correctly checked after.
- Pharmacy test. This one needed to be changed because the new version of Chrome (87) does not support the previous way to run the test (searching by address). So, I had to change to search by **zip code** and some other changes to suit this new type of search.
